### PR TITLE
[#BCNDEV354] - Fix module name to full package name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module mazzaroth-go
+module github.com/kochavalabs/mazzaroth-go
 
 go 1.16
 


### PR DESCRIPTION
Change the module name to the full package path.