### PR TITLE
Change NewProductionClientWithDefaultHTTPClient to receive list of comma separated list of servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,5 @@ test:
 
 integration:
 	go test ./... -count=1 -tags=integration
+
+testall: test integration

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,9 @@ github.com/kochavalabs/mazzaroth-xdr v0.2.5 h1:f2yd9imzWoUg1E0ceHe5SFbaIc2qJrF9b
 github.com/kochavalabs/mazzaroth-xdr v0.2.5/go.mod h1:0clNxqZ+8rf6toSNlUhuDRmbRVIBMiC2hkHD5I74shE=
 github.com/nullstyle/go-xdr v0.0.0-20180726165426-f4c839f75077 h1:A804awGqaW7i61y8KnbtHmh3scqbNuTJqcycq3u5ZAU=
 github.com/nullstyle/go-xdr v0.0.0-20180726165426-f4c839f75077/go.mod h1:sZZi9x5aHXGZ/RRp7Ne5rkvtDxZb7pd7vgVA+gmE35A=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e h1:n/hfey8pO+RYMoGXyvyzuw5pdO8IFDoyAL/g5OiCesY=
 github.com/stellar/go-xdr v0.0.0-20180917104419-0bc96f33a18e/go.mod h1:gpOLVzy6TVYTQ3LvHSN9RJC700FkhFCpSE82u37aNRM=

--- a/v1/clientproduction.go
+++ b/v1/clientproduction.go
@@ -35,11 +35,11 @@ func NewProductionClient(httpClient *http.Client, servers ...string) (*Productio
 }
 
 // NewProductionClientWithDefaultHTTPClient creates a production object.
-func NewProductionClientWithDefaultHTTPClient(server string) (*ProductionClient, error) {
+func NewProductionClientWithDefaultHTTPClient(servers ...string) (*ProductionClient, error) {
 	client := http.Client{
 		Timeout: 500 * time.Millisecond,
 	}
-	return NewProductionClient(&client, server)
+	return NewProductionClient(&client, servers...)
 }
 
 // TransactionSubmit calls the endpoint: /transaction/submit.

--- a/v1/test/clientproduction_test.go
+++ b/v1/test/clientproduction_test.go
@@ -10,9 +10,8 @@ import (
 	"net/http"
 	"testing"
 
-	v1 "mazzaroth-go/v1"
-	xdrtypes "mazzaroth-go/v1/test/xdr"
-
+	v1 "github.com/kochavalabs/mazzaroth-go/v1"
+	xdrtypes "github.com/kochavalabs/mazzaroth-go/v1/test/xdr"
 	"github.com/kochavalabs/mazzaroth-xdr/xdr"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## Description
The constructor function ```NewProductionClientWithDefaultHTTPClient``` was receiving a single Mazzaroth node when it was actually meant to receive a list of them.

## Related Issue
N/A

## Motivation and Context
This PR is part of the Mazzaroth project.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A
