### PR TITLE
Transaction Builder to match Mazzaroth-js functionality

### DIFF
--- a/client.go
+++ b/client.go
@@ -15,3 +15,16 @@ type Client interface {
 	NonceLookup(accountID xdr.ID) (*xdr.AccountNonceLookupResponse, error)
 	ChannelInfoLookup(channelInfoType xdr.ChannelInfoType) (*xdr.ChannelInfoLookupResponse, error)
 }
+
+// SigningClient : a Mazzaroth's client that also stores the user's private key, helping the user with signing operations 
+type SigningClient interface {
+	CallAction(action xdr.Action, authority *xdr.Authority) (*xdr.TransactionSubmitResponse, error)
+	ReadOnly(function string, parameters ...xdr.Parameter) (*xdr.ReadonlyResponse, error)
+	TransactionLookup(transactionID xdr.ID) (*xdr.TransactionLookupResponse, error)
+	ReceiptLookup(transactionID xdr.ID) (*xdr.ReceiptLookupResponse, error)
+	BlockLookup(blockID xdr.Identifier) (*xdr.BlockLookupResponse, error)
+	BlockHeaderLookup(blockID xdr.Identifier) (*xdr.BlockHeaderLookupResponse, error)
+	AccountInfoLookup(accountID xdr.ID) (*xdr.AccountInfoLookupResponse, error)
+	NonceLookup(accountID xdr.ID) (*xdr.AccountNonceLookupResponse, error)
+	ChannelInfoLookup(channelInfoType xdr.ChannelInfoType) (*xdr.ChannelInfoLookupResponse, error)
+}

--- a/signingclient.go
+++ b/signingclient.go
@@ -1,0 +1,79 @@
+package mazzaroth
+
+import (
+	"crypto/ed25519"
+
+	"github.com/kochavalabs/mazzaroth-xdr/xdr"
+	"github.com/pkg/errors"
+)
+
+var _ SigningClient = &SigningClientImpl{}
+
+// SigningClientImpl : is the actual implementation of ClientWithPrivateKey interface
+type SigningClientImpl struct {
+	client     *ClientImpl
+	privateKey ed25519.PrivateKey
+}
+
+// NewMazzarothSigningClient : builds a client storing your privateKey, accpts a custom-configured http.Client
+func NewMazzarothSigningClient(privateKey ed25519.PrivateKey, servers []string, options ...Options) (*SigningClientImpl, error) {
+	client, err := NewMazzarothClient(servers, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &SigningClientImpl{privateKey: privateKey, client: client}, nil
+}
+
+// CallAction : makes a transaction with the given action call
+func (cl *SigningClientImpl) CallAction(action xdr.Action, authority *xdr.Authority) (*xdr.TransactionSubmitResponse, error) {
+    txBuilder := NewTransactionBuilder().WithAction(action)
+	if authority != nil {
+		txBuilder = txBuilder.WithAuthority(*authority)
+	}
+    tx, err := txBuilder.Sign(cl.privateKey)
+	if err != nil {
+	    return nil, errors.Wrap(err, "in signing the transaction")
+
+	}
+	return cl.client.TransactionSubmit(*tx)
+}
+
+// ReadOnly calls the endpoint: /readonly.
+func (cl *SigningClientImpl) ReadOnly(function string, parameters ...xdr.Parameter) (*xdr.ReadonlyResponse, error) {
+	return cl.client.ReadOnly(function, parameters...)
+}
+
+// TransactionLookup calls the endpoint: /transaction/lookup.
+func (cl *SigningClientImpl) TransactionLookup(transactionID xdr.ID) (*xdr.TransactionLookupResponse, error) {
+	return cl.client.TransactionLookup(transactionID)
+}
+
+// ReceiptLookup calls the endpoint: /receipt/lookup.
+func (cl *SigningClientImpl) ReceiptLookup(transactionID xdr.ID) (*xdr.ReceiptLookupResponse, error) {
+	return cl.client.ReceiptLookup(transactionID)
+}
+
+// BlockLookup calls the endpoint: /block/lookup.
+func (cl *SigningClientImpl) BlockLookup(blockID xdr.Identifier) (*xdr.BlockLookupResponse, error) {
+	return cl.client.BlockLookup(blockID)
+}
+
+// BlockHeaderLookup calls the endpoint: /block/header/lookup.
+func (cl *SigningClientImpl) BlockHeaderLookup(blockID xdr.Identifier) (*xdr.BlockHeaderLookupResponse, error) {
+	return cl.client.BlockHeaderLookup(blockID)
+}
+
+// AccountInfoLookup calls the endpoint: /account/info/lookup.
+func (cl *SigningClientImpl) AccountInfoLookup(accountID xdr.ID) (*xdr.AccountInfoLookupResponse, error) {
+	return cl.client.AccountInfoLookup(accountID)
+}
+
+// NonceLookup calls the endpoint: /account/nonce/lookup.
+func (cl *SigningClientImpl) NonceLookup(accountID xdr.ID) (*xdr.AccountNonceLookupResponse, error) {
+	return cl.client.NonceLookup(accountID)
+}
+
+// ChannelInfoLookup calls the endpoint: /channel/info/lookup.
+func (cl *SigningClientImpl) ChannelInfoLookup(channelInfoType xdr.ChannelInfoType) (*xdr.ChannelInfoLookupResponse, error) {
+	return cl.client.ChannelInfoLookup(channelInfoType)
+}

--- a/test/signingclient_test.go
+++ b/test/signingclient_test.go
@@ -1,0 +1,56 @@
+// +build integration
+
+package mazzarothtest
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/json"
+	"testing"
+
+	"github.com/kochavalabs/mazzaroth-go"
+	xdrtypes "github.com/kochavalabs/mazzaroth-go/test/xdr"
+
+	"github.com/kochavalabs/mazzaroth-xdr/xdr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActionCall(t *testing.T) {
+	privateKeyBuffer := bytes.Repeat([]byte{0}, ed25519.SeedSize)
+	privateKey := ed25519.NewKeyFromSeed(privateKeyBuffer)
+
+	client, err := mazzaroth.NewMazzarothSigningClient(privateKey, []string{server})
+	require.NoError(t, err)
+
+	foo := xdrtypes.Foo{
+		Status: 100,
+		One:    "one",
+		Two:    "two",
+		Three:  "three",
+	}
+
+	fooBytes, err := json.Marshal(&foo)
+	require.NoError(t, err)
+	callParameters := []xdr.Parameter{xdr.Parameter(fooBytes)}
+	call := xdr.Call{
+		Function:   "insert_foo",
+		Parameters: callParameters,
+	}
+	address, err := xdr.IDFromPublicKey(privateKey.Public())
+	require.NoError(t, err)
+	var channel xdr.ID
+	nonce := uint64(2000)
+
+	cat, err := xdr.NewActionCategory(xdr.ActionCategoryTypeCALL, call)
+	action := xdr.Action{
+		Address:   address,
+		ChannelID: channel,
+		Nonce:     nonce,
+		Category:  cat,
+	}
+
+	resp, err := client.CallAction(action, nil)
+	require.NoError(t, err)
+	require.Equal(t, xdr.TransactionStatusACCEPTED, resp.Status)
+	require.Equal(t, xdr.StatusInfo("Transaction has been accepted and is being executed."), resp.StatusInfo)
+}


### PR DESCRIPTION
Making a second client that wraps the bareclient and holds the user's
privateKey so they can directly pass actions without warrying about
changing permissions