### PR TITLE
feat(abi-lookup): update to mazzaroth-xdr v0.5.0 and add AbiLookup Client function

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,4 +13,5 @@ type Client interface {
 	AccountInfoLookup(accountID xdr.ID) (*xdr.AccountInfoLookupResponse, error)
 	ChannelInfoLookup(channelInfoType xdr.ChannelInfoType) (*xdr.ChannelInfoLookupResponse, error)
 	BlockHeightLookup() (uint64, error)
+	AbiLookup(channelID xdr.ID) (*xdr.Abi, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/kochavalabs/crypto v0.0.0-20210414182029-6a8321e05fdc
-	github.com/kochavalabs/mazzaroth-xdr v0.4.3
+	github.com/kochavalabs/mazzaroth-xdr v0.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kochavalabs/crypto v0.0.0-20210414182029-6a8321e05fdc h1:OaMOjAZN//rK7fPvynOzieupjbxl5lwxk/3u1YvE//U=
 github.com/kochavalabs/crypto v0.0.0-20210414182029-6a8321e05fdc/go.mod h1:qTHYQRl9gCAPCCXxCxpMbeNU7nV5VyFgMfPMDHcYlXA=
-github.com/kochavalabs/mazzaroth-xdr v0.4.3 h1:NKQju34DasG8REt0huIIA5E9GTj5uY2/Uk05mQu+ZKM=
-github.com/kochavalabs/mazzaroth-xdr v0.4.3/go.mod h1:eTiDhRRYpBIS6nrl3n7jKp3d3eqRo/IszURbPs6xR5A=
+github.com/kochavalabs/mazzaroth-xdr v0.5.0 h1:QYGMole8lNO/uHFECoNK0VFCEcseEUojdn+oE8i4Mmc=
+github.com/kochavalabs/mazzaroth-xdr v0.5.0/go.mod h1:eTiDhRRYpBIS6nrl3n7jKp3d3eqRo/IszURbPs6xR5A=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -194,3 +194,15 @@ func TestBlockHeightLookup(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), height)
 }
+
+// TestABILookup
+func TestABILookup(t *testing.T) {
+	options := []mazzaroth.Options{}
+	client, err := mazzaroth.NewMazzarothClient([]string{server}, options...)
+	require.NoError(t, err)
+
+	testAddress, _ := xdr.IDFromSlice([]byte("00000000000000000000000000000000"))
+	abi, err := client.AbiLookup(testAddress)
+	require.NoError(t, err)
+	require.Equal(t, &xdr.Abi{Functions: []xdr.FunctionSignature{xdr.FunctionSignature{FunctionType: "function", Name: "setup", Inputs: []xdr.Parameter(nil), Outputs: []xdr.Parameter{xdr.Parameter{Name: "returnValue0", ParameterType: "bool", Codec: "bytes"}}}, xdr.FunctionSignature{FunctionType: "readonly", Name: "simple", Inputs: []xdr.Parameter(nil), Outputs: []xdr.Parameter{xdr.Parameter{Name: "returnValue0", ParameterType: "string", Codec: "bytes"}}}, xdr.FunctionSignature{FunctionType: "function", Name: "args", Inputs: []xdr.Parameter{xdr.Parameter{Name: "one", ParameterType: "string", Codec: "bytes"}, xdr.Parameter{Name: "two", ParameterType: "string", Codec: "bytes"}, xdr.Parameter{Name: "three", ParameterType: "string", Codec: "bytes"}}, Outputs: []xdr.Parameter{xdr.Parameter{Name: "returnValue0", ParameterType: "uint32", Codec: "bytes"}}}, xdr.FunctionSignature{FunctionType: "function", Name: "complex", Inputs: []xdr.Parameter{xdr.Parameter{Name: "foo_arg", ParameterType: "Foo", Codec: "bytes"}, xdr.Parameter{Name: "bar_arg", ParameterType: "Bar", Codec: "bytes"}}, Outputs: []xdr.Parameter{xdr.Parameter{Name: "returnValue0", ParameterType: "string", Codec: "bytes"}}}, xdr.FunctionSignature{FunctionType: "function", Name: "insert_foo", Inputs: []xdr.Parameter{xdr.Parameter{Name: "foo", ParameterType: "Foo", Codec: "bytes"}}, Outputs: []xdr.Parameter{xdr.Parameter{Name: "returnValue0", ParameterType: "int32[]", Codec: "bytes"}}}, xdr.FunctionSignature{FunctionType: "function", Name: "query_foo", Inputs: []xdr.Parameter{xdr.Parameter{Name: "where_clause", ParameterType: "string", Codec: "bytes"}}, Outputs: []xdr.Parameter{xdr.Parameter{Name: "returnValue0", ParameterType: "Foo[]", Codec: "bytes"}}}}}, abi)
+}


### PR DESCRIPTION
# Description

- Added the AbiLookup client function which works with the latest version of Mazzaroth.
- Updated to use mazzaroth-xdr v0.5.0

- Also fixed issue where Status Code checks were returning nil error because they were wrapping a nil error.  Changed these to instead just create a new error.